### PR TITLE
Add new configuration settings

### DIFF
--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -29,6 +29,7 @@ data "template_file" "load_snapshot" {
     snapshot_repository_read_only = "${var.snapshot_repository_read_only}"
     high_disk_watermark               = "${var.elasticsearch_high_disk_watermark}"
     low_disk_watermark               = "${var.elasticsearch_low_disk_watermark}"
+    elasticsearch_delayed_allocation  = "${var.elasticsearch_delayed_allocation}"
   }
 }
 

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -13,6 +13,7 @@ data "template_file" "setup" {
     minimum_master_nodes              = "${var.elasticsearch_desired_instances/2 + 1}"
     elasticsearch_heap_memory_percent = "${var.elasticsearch_heap_memory_percent}"
     elasticsearch_fielddata_limit     = "${var.elasticsearch_fielddata_limit}"
+    elasticsearch_search_queue_size   = "${var.elasticsearch_search_queue_size}"
   }
 }
 

--- a/templates/load_snapshot.sh.tpl
+++ b/templates/load_snapshot.sh.tpl
@@ -11,6 +11,7 @@ snapshot_name="${snapshot_name}"
 read_only="${snapshot_repository_read_only}"
 alias_name="${snapshot_alias_name}"
 replica_count="${snapshot_replica_count}"
+elasticsearch_delayed_allocation="${elasticsearch_delayed_allocation}"
 
 # check all required variables are set
 if [[ "$s3_bucket" == "" ]]; then
@@ -117,7 +118,17 @@ curl -s -XPUT --fail "$cluster_url/$snapshot_name/_settings" -d "{
   }
 }"
 
-## 6. make cluster read_only (prevents deletion of indices)
+## 6. Set index specific settings
+
+if [[ "$elasticsearch_delayed_allocation" != "" ]]; then
+  curl -s -XPUT --fail "$cluster_url/$snapshot_name/_settings" -d "{
+    \"settings\" : {
+      \"index.unassigned.node_left.delayed_timeout\": \"$elasticsearch_delayed_allocation\"
+    }
+  }"
+fi
+
+## 7. make cluster read_only (prevents deletion of indices)
 curl -s -XPUT --fail "$cluster_url/_cluster/settings" -d '{
   "persistent" : {
     "cluster.blocks.read_only" : true

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -33,6 +33,11 @@ gateway.expected_nodes: ${expected_nodes}
 indices.breaker.fielddata.limit: ${elasticsearch_fielddata_limit}
 EOF
 
+## set search queue size if set
+if [[ "${elasticsearch_search_queue_size}" != "" ]]; then
+  echo "thread_pool.search.queue_size: ${elasticsearch_search_queue_size}" >> /etc/elasticsearch/elasticsearch.yml
+fi
+
 # elasticsearch 2.4 specific settings
 # note: we can check if 'bin/plugin' exists, this was renamed after 2.4
 if [ -f '/usr/share/elasticsearch/bin/plugin' ]; then

--- a/variables.tf
+++ b/variables.tf
@@ -103,6 +103,11 @@ variable "elasticsearch_fielddata_limit" {
   default     = "30%"
 }
 
+variable "elasticsearch_search_queue_size" {
+  description = "the thread_pool queue size for searches. Defaults to ES default (1000) if unset"
+  default     = ""
+}
+
 # disk based shard allocation filtering settings
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html
 variable "elasticsearch_high_disk_watermark" {

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "elasticsearch_search_queue_size" {
   default     = ""
 }
 
+# https://www.elastic.co/guide/en/elasticsearch/reference/master/delayed-allocation.html
+variable "elasticsearch_delayed_allocation" {
+  description = "The time to wait after a node leaves before re-allocating shards. ES default of 1 minute used if unset"
+  default     = ""
+}
+
 # disk based shard allocation filtering settings
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html
 variable "elasticsearch_high_disk_watermark" {


### PR DESCRIPTION
This PR allows configuring two important Elasticsearch settings:

- [delayed allocation timeout](https://www.elastic.co/guide/en/elasticsearch/reference/master/delayed-allocation.html): how long the cluster waits after a node disappears before deciding where to allocate shards that were lost. Adjusting this property can help ensure that shards are restored directly to a newly launched replacement node, without any extra "churn" where shards are transferred around needlessly

- [search thread_pool queue size](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-threadpool.html#modules-threadpool): The default Elasticsearch search threadpool queue size is 1000. This is optimal for batch processing or analysis queries such as Kibana where waiting for a result is preferred and the response time for that result is not as important. For latency sensitive workloads like autocomplete, a pool size of 1000 is too big.