### PR TITLE
Availability Zone allocation awareness

### DIFF
--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -14,6 +14,7 @@ data "template_file" "setup" {
     elasticsearch_heap_memory_percent = "${var.elasticsearch_heap_memory_percent}"
     elasticsearch_fielddata_limit     = "${var.elasticsearch_fielddata_limit}"
     elasticsearch_search_queue_size   = "${var.elasticsearch_search_queue_size}"
+    allocation_awareness_attributes   = "${var.allocation_awareness_attributes}"
   }
 }
 

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -21,6 +21,7 @@ discovery.zen.minimum_master_nodes: ${minimum_master_nodes}
 discovery.ec2.groups: ${aws_security_group}
 discovery.ec2.availability_zones: [${availability_zones}]
 
+cloud.node.auto_attributes: true
 cloud.aws.region: ${aws_region}
 repositories.url.allowed_urls: ["${es_allowed_urls}"]
 

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -e
 
-# Ideally move all this to a proper config management tool
-#
-# Configure elasticsearch
+# Generate elasticsearch.yml
 
 cat <<'EOF' >/etc/elasticsearch/elasticsearch.yml
 cluster.name: ${es_cluster_name}

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -5,6 +5,8 @@ set -e
 
 cat <<'EOF' >/etc/elasticsearch/elasticsearch.yml
 cluster.name: ${es_cluster_name}
+cluster.routing.allocation.awareness.attributes: ${allocation_awareness_attributes}
+
 node.name: $${HOSTNAME} # the $${HOSTNAME} var is filled in by Elasticsearch
 
 # our init.d script sets the default to this as well

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,12 @@ variable "elasticsearch_low_disk_watermark" {
   default = ""
 }
 
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-awareness.html#enabling-awareness
+variable "allocation_awareness_attributes" {
+  description = "attributes to use to determine shard placement"
+  default     = "aws_availability_zone"
+}
+
 ## snapshot loading settings
 variable "snapshot_s3_bucket" {
   description = "The bucket where ES snapshots can be loaded from S3."


### PR DESCRIPTION
When using an Elasticsearch cluster spread across multiple EC2 availability zones, it makes sense to ensure that replica shards are always in a different availability zone than the corresponding primary shard.

While not 100% guaranteed, AWS designs availability zones to be generally independent in terms of outages, so it can make a cluster much more resilient against failure.

This PR uses the [EC2 Discovery plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/5.6/discovery-ec2-discovery.html#discovery-ec2-attributes) to set the availability attribute on each node, and then use shard allocation awareness on the availability zone property to ensure shards are well distributed.

Closes https://github.com/pelias/terraform-elasticsearch/issues/5