### PR TITLE
Elasticsearch7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This repository attempts to collect best practices for a production-ready Elasti
 
 - Terraform 0.11.x: Terraform 0.12 is [not yet supported](https://github.com/pelias/terraform-elasticsearch/issues/4)
 
+## Compatibility
+
+This project is compatible with Elasticsearch 7 _only_. Use historical releases
+before `v7.0.0` to support Elasticsearch 5 or 6. Going forward, the major
+version of this project will track the supported Elasticsearch major version.
+
 ## Setup instructions
 
 ### Create a terraform user

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -10,7 +10,6 @@ data "template_file" "setup" {
     aws_region                        = "${var.aws_region}"
     availability_zones                = "${var.availability_zones}"
     expected_nodes                    = "${var.elasticsearch_desired_instances}"
-    minimum_master_nodes              = "${var.elasticsearch_desired_instances/2 + 1}"
     elasticsearch_heap_memory_percent = "${var.elasticsearch_heap_memory_percent}"
     elasticsearch_fielddata_limit     = "${var.elasticsearch_fielddata_limit}"
     elasticsearch_search_queue_size   = "${var.elasticsearch_search_queue_size}"

--- a/policies/policy.json
+++ b/policies/policy.json
@@ -2,7 +2,9 @@
     "Statement": [
         {
             "Action": [
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances"
             ],
             "Effect": "Allow",
             "Resource": [

--- a/templates/load_snapshot.sh.tpl
+++ b/templates/load_snapshot.sh.tpl
@@ -144,12 +144,4 @@ if [[ "$elasticsearch_delayed_allocation" != "" ]]; then
     }"
 fi
 
-## 7. make cluster read_only (prevents deletion of indices)
-curl -s -XPUT --fail "$cluster_url/_cluster/settings" \
-  -H 'Content-Type: application/json' \
-  -d '{
-  "persistent" : {
-    "cluster.blocks.read_only" : true
-  }
-}'
-echo
+echo "All done setting up Elasticsearch snapshot"

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -24,7 +24,6 @@ discovery.ec2.groups: ${aws_security_group}
 discovery.ec2.availability_zones: [${availability_zones}]
 
 cloud.node.auto_attributes: true
-repositories.url.allowed_urls: ["${es_allowed_urls}"]
 
 gateway.recover_after_time: 5m
 gateway.expected_nodes: ${expected_nodes}

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -37,7 +37,6 @@ bootstrap.memory_lock: true
 network.host: [ '_ec2:privateIpv4_', _local_ ]
 network.publish_host: '_ec2:privateIpv4_'
 discovery.seed_providers: ec2
-discovery.zen.minimum_master_nodes: ${minimum_master_nodes}
 discovery.ec2.groups: ${aws_security_group}
 discovery.ec2.availability_zones: [${availability_zones}]
 

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -18,7 +18,7 @@ bootstrap.memory_lock: true
 
 network.host: [ '_ec2:privateIpv4_', _local_ ]
 network.publish_host: '_ec2:privateIpv4_'
-discovery.zen.hosts_provider: ec2
+discovery.seed_providers: ec2
 discovery.zen.minimum_master_nodes: ${minimum_master_nodes}
 discovery.ec2.groups: ${aws_security_group}
 discovery.ec2.availability_zones: [${availability_zones}]

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -45,7 +45,8 @@ cluster.initial_master_nodes: [ $asg_ip_list ]
 cloud.node.auto_attributes: true
 
 gateway.recover_after_time: 5m
-gateway.expected_nodes: ${expected_nodes}
+gateway.recover_after_nodes: ${expected_nodes}
+gateway.expected_data_nodes: ${expected_nodes}
 
 # circuit breakers
 indices.breaker.fielddata.limit: ${elasticsearch_fielddata_limit}


### PR DESCRIPTION
This PR adds support for Elasticsearch 7!

Support for ES7 is a big, **breaking** change, as all master-eligible nodes present at cluster creation [must be hard-coded across all nodes](https://www.elastic.co/guide/en/elasticsearch/reference/master/discovery-settings.html#initial_master_nodes). The [AWS CLI](https://aws.amazon.com/cli/), along with some additional permissions on the part of the EC2 instance IAM profile performs this.

Connects https://github.com/pelias/pelias/issues/831