### PR TITLE
feat: Allow filtering subnets by any tag

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "subnet_name_filter" {
   default     = "Elasticsearch"
 }
 
+variable "subnet_name_filter_property" {
+  description = "Filter subnets within the VPC by using this name"
+  default     = "tag:Name"
+}
+
 # security settings
 variable "ssh_ip_range" {
   description = "Range of IPs able to SSH into the Elasticsearch nodes"

--- a/vpc.tf
+++ b/vpc.tf
@@ -3,7 +3,8 @@
 data "aws_subnet_ids" "all_subnets" {
   vpc_id = "${var.aws_vpc_id}"
 
-  tags {
-    Name = "${var.subnet_name_filter}"
+  filter {
+    name = "${var.subnet_name_filter_property}"
+    values = ["${var.subnet_name_filter}"]
   }
 }


### PR DESCRIPTION
This change allows filtering the list of subnets within which EC2
instances are launched.

Previously, they could only be filtered by name, and only using prefix
matching, something like "my-subnet-*".

The second restriction is still in place, however now any tag can be
used, which means arbitrary collections of subnets can be selected as
long as a tag enumerating them exists on the subnets.

This requires a new configuration variable, which defaults to the subnet
`Name` tag to ensure backwards compatibility.