### PR TITLE
Ensure Elasticsearch is restarted on reboot

### DIFF
--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -115,6 +115,9 @@ fi
 # Start Elasticsearch
 sudo service elasticsearch start
 
+# Ensure Elasticsearch restarts after reboot
+sudo systemctl enable elasticsearch
+
 # Import elastic status/wait scripts
 . /home/ubuntu/elastic_wait.sh
 


### PR DESCRIPTION
Very simple, currently rebooting an EC2 instance using this project will not cause Elasticsearch to restart.