### PR TITLE
Fix ec2 discovery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ module "elasticsearch-prod-a" {
 
   aws_vpc_id   = "vpc-1234" # the ID of an existing VPC in which to create the instances
   ssh_key_name = "ssh-key-to-use"
+  availability_zones = "us-east-1a,us-east-1b,us-east-1c" # List of availability zones to use. Optional in us-east-1, required otherwise
 
   environment                       = "dev" # or whatever unique environment you choose
   elasticsearch_max_instances       = 2 # 2 r5.large instances is suitable for a minimal full-planet production build with replicas

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -39,6 +39,7 @@ network.publish_host: '_ec2:privateIpv4_'
 discovery.seed_providers: ec2
 discovery.ec2.groups: ${aws_security_group}
 discovery.ec2.availability_zones: [${availability_zones}]
+discovery.ec2.endpoint: ec2.$${region}.amazonaws.com
 
 cluster.initial_master_nodes: [ $asg_ip_list ]
 


### PR DESCRIPTION
When working in a region other than `us-east-1`, ec2 discovery does not work. [discovery.ec2.endpoint](https://www.elastic.co/guide/en/elasticsearch/plugins/current/discovery-ec2-usage.html#_configuring_ec2_discovery) must be set to the corresponding region in which the cluster is.

I also added in the example config a note to make clear that `discovery.ec2.availability_zones` should specified too in such case. 