### PR TITLE
fix: Handle '.geoip_database' index when creating alias

### DIFF
--- a/templates/load_snapshot.sh.tpl
+++ b/templates/load_snapshot.sh.tpl
@@ -97,7 +97,7 @@ curl -s -XPOST --fail "$cluster_url/_snapshot/$es_repo_name/$snapshot_name/_rest
   -H 'Content-Type: application/json'
 
 ## 3.1 get first index name
-first_index_name=$(curl -s "$cluster_url/_cat/indices?format=json" | jq -r .[].index)
+first_index_name=$(curl -s "$cluster_url/_cat/indices?format=json" | jq -r .[].index | grep -v '.geoip_databases')
 echo "first index name is $first_index_name"
 
 ## 4. make alias if alias_name set


### PR DESCRIPTION
Newer versions of Elasticsearch (somewhere between 7.9 and 7.16) natively include a GeoIP database.

The code to set up the convenient 'pelias' Elasticsearch index alias gets tripped up by this, as it wasn't expecting any other indices to exist besides the main Pelias index.

We don't want to require people to name their Pelias indices anything specific (though they generally start with `pelias-` according to our project conventions).

What we can do is filter out the '.geoip_database' index when creating the alias. Then the first index seen will be a Pelias index.

This will allow us to support Elasticsearch 7.16.1 to mitigate the log4j security vulnerability https://github.com/pelias/pelias/issues/921