### PR TITLE
udev block device rule

### DIFF
--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -89,6 +89,20 @@ if [[ "$potential_nvme_disk" != "" ]]; then
   data_volume_name=$potential_nvme_disk
 fi
 
+# Automatic Mapping of NVMe-style EBS Volumes to Standard Block Device Paths
+# https://github.com/oogali/ebs-automatic-nvme-mapping
+sudo curl -s \
+  -o /usr/local/sbin/ebs-nvme-mapping.sh \
+  https://raw.githubusercontent.com/oogali/ebs-automatic-nvme-mapping/master/ebs-nvme-mapping.sh
+
+sudo curl -s \
+  -o /etc/udev/rules.d/999-aws-ebs-nvme.rules \
+  https://raw.githubusercontent.com/oogali/ebs-automatic-nvme-mapping/master/999-aws-ebs-nvme.rules
+
+sudo chmod +x /usr/local/sbin/ebs-nvme-mapping.sh
+sudo apt-get update -y && sudo apt-get install -y nvme-cli
+sudo udevadm control --reload-rules && udevadm trigger && udevadm settle
+
 sudo mkfs -t ext4 $data_volume_name
 sudo tune2fs -m 0 $data_volume_name
 sudo mkdir -p ${elasticsearch_data_dir}


### PR DESCRIPTION
add udev rule to ensure block device symlinks exist for modern nvme EBS mappings

for a while now I've noticed intermittent startup failures on smaller elasticsearch machines, I was never able to put my finger on the issue but I suspected a race between kernel tasks and `cloud-init`.

today I made some progress, mainly because upgrading to ubuntu focal seems to make it fail more consistently.

what I think is going on is that there is either a race between `cloud-init` and `udev`... or that udev isn't working properly due to `python2.7` not being available on modern Ubu distros.

but backing up a second, what's the issue?

well, with some more modern AWS machines you request an EBS block device mapping of something like `/dev/sdb` but when you boot it's actually available as `/dev/nvme2n1` or something similar 🤷‍♂️ 

it's kind of odd, but I believe that this is due to [the 'Nitro' system using an NVME driver for EBS volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html).

so to get around this blaring issue AWS encodes some 'vendor info' in the NVME mapping binary header which contains information about the mapping you actually requested.

there is then a udev rule (the last line below) which is responsible for detecting all this and creating a symlink:

```bash
cat /etc/udev/rules.d/10-aws.rules
KERNEL=="xvd*", PROGRAM="/sbin/ec2udev-vbd %k", SYMLINK+="%c"
KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", PROGRAM="/sbin/ebsnvme-id -u /dev/%k", SYMLINK+="%c"
```

when this symlink isn't created or isn't created YET, then things break:

```bash
mke2fs 1.45.5 (07-Jan-2020)
The file /dev/sdb does not exist and no size was specified.
waiting for elasticsearch service to come up
..............................

Elasticsearch did not come up, check configuration
```

the udev rule installed by default seems to be broken on modern Ubu because it runs `/sbin/ebsnvme-id` which doesn't work because it requires `python2.7` which isn't installed 😢 

I tried installing `python2.7` and trigger the rules and it still doesn't work so 🤷‍♂️ 

that's when I found this article https://opensource.creativecommons.org/blog/entries/2020-04-03-nvmee-on-debian-on-aws/ pointing me to https://github.com/oogali/ebs-automatic-nvme-mapping