### PR TITLE
tunable elastic_wait.sh vars

### DIFF
--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -14,6 +14,8 @@ data "template_file" "setup" {
     elasticsearch_fielddata_limit     = "${var.elasticsearch_fielddata_limit}"
     elasticsearch_search_queue_size   = "${var.elasticsearch_search_queue_size}"
     allocation_awareness_attributes   = "${var.allocation_awareness_attributes}"
+    elasticsearch_wait_retry_count    = "${var.elasticsearch_wait_retry_count}"
+    elasticsearch_wait_retry_timeout  = "${var.elasticsearch_wait_retry_timeout}"
   }
 }
 

--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -120,6 +120,8 @@ sudo service elasticsearch start
 sudo systemctl enable elasticsearch
 
 # Import elastic status/wait scripts
+export ELASTIC_RETRY_COUNT="${elasticsearch_wait_retry_count}"
+export ELASTIC_RETRY_TIMEOUT="${elasticsearch_wait_retry_timeout}"
 . /home/ubuntu/elastic_wait.sh
 
 # Wait for elasticsearch service to come up (note elastic_wait exits 0|1); then

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,16 @@ variable "elasticsearch_log_volume_type" {
   default = "gp2"
 }
 
+variable "elasticsearch_wait_retry_count" {
+  description = "total number of iterations for the elastic_wait command"
+  default = "30"
+}
+
+variable "elasticsearch_wait_retry_timeout" {
+  description = "delay per iteration for the elastic_wait command (in seconds)"
+  default = "1"
+}
+
 # AMI Settings
 
 variable "ami_env_tag_filter" {


### PR DESCRIPTION
this PR allows the environment variables used by `~/elastic_wait.sh` to be tunable.

```
# note: moved to shell script rather than being inline in a template file due to:
# https://github.com/terraform-providers/terraform-provider-template/issues/51

ELASTIC_RETRY_COUNT=${ELASTIC_RETRY_COUNT:-30}
ELASTIC_RETRY_TIMEOUT=${ELASTIC_RETRY_TIMEOUT:-1}

function elastic_status(){
  curl \
```