### PR TITLE
Fix unbound variable in Elasticsearch setup

### DIFF
--- a/templates/setup.sh.tpl
+++ b/templates/setup.sh.tpl
@@ -14,8 +14,8 @@ asg_name=$(aws autoscaling describe-auto-scaling-instances --region $region --ou
 instance_ids=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names $asg_name --output text --region $region \
         --query "AutoScalingGroups[0].Instances[].InstanceId")
 
-instance_ips=$(echo $instance_ids | xargs -n1 aws ec2 describe-instances --instance-ids $ID --region $region \
-        --query "Reservations[].Instances[].PrivateIpAddress" --output text)
+instance_ips=$(echo $instance_ids | xargs -n1 aws ec2 describe-instances --region $region \
+        --query "Reservations[].Instances[].PrivateIpAddress" --output text --instance-ids)
 
 asg_ip_list=$(join_by , $instance_ips)
 


### PR DESCRIPTION
This minor error has been sitting in our code for 5 years with no real impact: it didn't affect the final output but will break if you use `set -u` to error on unbound variables.

Apparently, the `aws ec2 describe-instances` command can accept parameters in weird orders that [the docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-instances.html#options) don't suggest should work.

Basically, the line was of the form like this:

`aws ec2 describe-instances --instance-ids $unbound_variable --output json $some_instance_ids_passed_in_by_xargs`

To me this _should_ have been an error since the `instance_ids` parameter should have its inputs be immediately following. But it always worked.

This PR simply changes that line so that the unbound variable is no longer referenced, and moves the `--instance-ids` flag to the end of the line so at least the meaning is hopefully clearer.

:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
